### PR TITLE
Add permissions section and integration job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,7 @@ jobs:
   
   integration:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: none
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,11 @@ jobs:
       - run: yarn install
       - run: yarn build
       - run: yarn test --passWithNoTests
+  
+  integration:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: none
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ them accordingly.
 
 See [action.yml](./action.yml) for a complete list of inputs and outputs.
 
+## Permissions
+
+This action requires the following permissions:
+
+```yaml
+permissions:
+```
+
 ## Versioning
 
 Versioned tags will exist, such as `v1.0.0` and `v2.1.1`. Branches will exist

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ permissions: {}
 ```
 
 As the action uses the GitHub API, these should be updated to reflect the
-minimal scopes permissions required. These permissions may need to be
-manually set in certain scenarios, such as workflows triggered by Dependabot
-PRs, which use a read-only `GITHUB_TOKEN`.
+minimal permissions required. These permissions may need to be manually set in
+certain scenarios, such as workflows triggered by Dependabot PRs, which use a
+read-only `GITHUB_TOKEN`.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ See [action.yml](./action.yml) for a complete list of inputs and outputs.
 This action requires the following permissions:
 
 ```yaml
-permissions:
+permissions: {}
 ```
+
+As the action uses the GitHub API, these should be updated to reflect the
+minimal scopes permissions required. These permissions may need to be
+manually set in certain scenarios, such as workflows triggered by Dependabot
+PRs, which use a read-only `GITHUB_TOKEN`.
 
 ## Versioning
 


### PR DESCRIPTION
Adds a section in the README and an `integration` job to the CI workflow to motivate future uses of this template to specify the minimal permissions required to run the action. This is good to have when workflows are triggered by Dependabot or are otherwise run in repositories with less permissive defaults for workflow runs.

See also: https://github.com/freckle/commenter-action/pull/401