### PR TITLE
chore: disable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   release:
+    if: false # remove this when you are ready to release your action
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
It doesn't work, so might as well have it not failing all the time.
