### PR TITLE
fix: set up Node via .nvmrc before running semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: actions/setup-node@v7
+        with:
+          cache: yarn
+          node-version-file: ".nvmrc"
+
       - id: token
         uses: actions/create-github-app-token@v3
         with:


### PR DESCRIPTION
## The gap

`.github/workflows/release.yml` never sets up Node/Yarn before invoking `cycjimmy/semantic-release-action@v6.0.0`.

## Why it matters

`cycjimmy/semantic-release-action`'s `action.yml` declares:

```yaml
runs:
  using: 'node24'
  main: 'index.js'
```

(verified via `gh api repos/cycjimmy/semantic-release-action/contents/action.yml`)

That's a plain Node.js action, not a Docker container action — it executes directly on the `ubuntu-latest` runner's own filesystem/toolchain, using whatever `node`/`yarn` already happen to be on `PATH`. It does **not** bring its own isolated Node version.

This repo's `.releaserc.yaml` includes an `@semantic-release/exec` step with `prepareCmd: "yarn install && yarn run build"`, which runs *inside* the semantic-release-action process. Since that action runs on the runner's ambient Node rather than an isolated one, this build command executes against whatever Node version happens to be preinstalled on the runner image — not the version pinned in this repo's `.nvmrc`.

Compare to `.github/workflows/ci.yml`, which correctly sets up Node before running any yarn commands:

```yaml
- uses: actions/checkout@v7
- uses: actions/setup-node@v7
  with:
    cache: yarn
    node-version-file: ".nvmrc"
- run: yarn install
- run: yarn test
- run: yarn lint
- run: yarn build
```

`release.yml` has no equivalent step, so a release build could silently use a different Node version than CI (and than what `yarn.lock`/`engines` expect) — risking inconsistent `dist/index.js` output between CI and release, or outright build failures if the runner's default Node version ever drifts from what this project needs.

This is the same category of gap a Freckle reviewer flagged on the sibling `cancelable-promise-js` semantic-release PR (freckle/cancelable-promise-js#152): needing to set up the package manager/runtime before the semantic-release action runs its build command, since that action runs directly on the runner rather than in an isolated container.

## The fix

Add an `actions/setup-node@v7` step, mirroring `ci.yml`, after checkout and before the `cycjimmy/semantic-release-action` step.

## Not changed

- `.releaserc.yaml` — no changes needed.
- The `if: false # remove this when you are ready to release your action` guard on the job — left in place; this is a template repo with no real action published yet, so the guard remains correct.

## Test plan

- [ ] CI passes on this branch (workflow YAML lints/parses correctly)
- [ ] When this template repo is eventually instantiated for a real action and the `if: false` guard is removed, confirm the release job builds `dist/index.js` using the `.nvmrc`-pinned Node version (verify via a `node --version` echo or by diffing dist output against a local build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)